### PR TITLE
Feat/add functionality to remove all blocked URLs at once

### DIFF
--- a/src/contentfilter/main.py
+++ b/src/contentfilter/main.py
@@ -281,7 +281,7 @@ async def import_json(
     return redir_resp
 
 
-@webapp.post("/clear/", name="clear_urls")
+@webapp.post("/remove/all", name="remove_all_urls")
 async def clear_urls(
     request: Request,
     username: str = AuthDependency,
@@ -295,13 +295,13 @@ async def clear_urls(
         if num_urls:
             flash(
                 request,
-                f"Successfully deleted {num_urls} blocked URL(s) from the list",
+                f"Successfully removed {num_urls} blocked URL(s) from the list",
                 "success",
             )
         else:
             flash(request, "The list was already empty", "info")
     except Exception as exc:
-        flash(request, f"Unable to clear URLs: {exc}.", "danger")
+        flash(request, f"Unable to remove URLs: {exc}.", "danger")
     return redir_resp
 
 

--- a/src/contentfilter/main.py
+++ b/src/contentfilter/main.py
@@ -281,4 +281,28 @@ async def import_json(
     return redir_resp
 
 
+@webapp.post("/clear/", name="clear_urls")
+async def clear_urls(
+    request: Request,
+    username: str = AuthDependency,
+):
+    redir_resp = RedirectResponse(
+        request.url_for("settings"), status_code=http.HTTPStatus.FOUND
+    )
+    try:
+        num_urls = len(database)
+        database.clear()
+        if num_urls:
+            flash(
+                request,
+                f"Successfully deleted {num_urls} blocked URL(s) from the list",
+                "success",
+            )
+        else:
+            flash(request, "The list was already empty", "info")
+    except Exception as exc:
+        flash(request, f"Unable to clear URLs: {exc}.", "danger")
+    return redir_resp
+
+
 app.mount(Conf.webroot_prefix, webapp)

--- a/src/contentfilter/templates/settings.html
+++ b/src/contentfilter/templates/settings.html
@@ -19,10 +19,10 @@
   </div>
 </form>
 
-<h2 class="mt-4">Clear all URLs</h2>
+<h2 class="mt-4">Delete all URLs</h2>
 <p>Remove all blocked URLs from your list. This action cannot be undone.</p>
-<form method="POST" action="{{ url_for('clear_urls') }}" onsubmit="return confirm('Are you sure you want to delete all blocked URLs? This cannot be undone.');">
-  <button type="submit" class="btn btn-danger"><i class="bi-trash" role="img"></i> Delete All URLs</button>
+<form method="POST" action="{{ url_for('remove_all_urls') }}" onsubmit="return confirm('Are you sure you want to delete all blocked URLs? This cannot be undone.');">
+  <button type="submit" class="btn btn-danger"><i class="bi-trash" role="img"></i> Delete All</button>
 </form>
 
 <hr />

--- a/src/contentfilter/templates/settings.html
+++ b/src/contentfilter/templates/settings.html
@@ -19,6 +19,12 @@
   </div>
 </form>
 
+<h2 class="mt-4">Clear all URLs</h2>
+<p>Remove all blocked URLs from your list. This action cannot be undone.</p>
+<form method="POST" action="{{ url_for('clear_urls') }}" onsubmit="return confirm('Are you sure you want to delete all blocked URLs? This cannot be undone.');">
+  <button type="submit" class="btn btn-danger"><i class="bi-trash" role="img"></i> Delete All URLs</button>
+</form>
+
 <hr />
 
 <h2>Settings</h2>


### PR DESCRIPTION
## Description
This PR implements the ability to remove all blocked URLs at once.

Fixes #1 

### Changes
- Added "Delete all URLs" section to settings page
- Added `/remove/all` endpoint to handle bulk deletion
- Added confirmation dialog to prevent accidental deletions

## Screenshots
<img width="1920" height="753" alt="Screenshot (88)" src="https://github.com/user-attachments/assets/2d977cf5-c059-4ee8-84b7-c733cfe594ac" />
<img width="1920" height="754" alt="Screenshot (89)" src="https://github.com/user-attachments/assets/4f371bf2-0dc0-4227-a174-bdc2f7948c05" />
<img width="1920" height="829" alt="Screenshot (90)" src="https://github.com/user-attachments/assets/391c3ecf-89a1-4d57-a453-6323aeb3b15c" />
